### PR TITLE
Change default decoder to simplejson with support for Decimal

### DIFF
--- a/ethtx_ce/app/api/decorators.py
+++ b/ethtx_ce/app/api/decorators.py
@@ -31,6 +31,8 @@ from .utils import enable_direct, delete_bstrings
 
 log = logging.getLogger(__name__)
 
+jsonpickle.set_decoder_options('simplejson', use_decimal=True)
+
 
 def auth_required(func: Callable):
     """api key  verification."""


### PR DESCRIPTION
Force the json decoder to simplejson with support for Decimal. Consequently, all Decimals are converted to strings in the returned API payload.